### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Code Multi-Agent Workflow System
 
+[![Run in Smithery](https://smithery.ai/badge/skills/cexll)](https://smithery.ai/skills?ns=cexll&utm_source=github&utm_medium=badge)
+
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude-Code-blue)](https://claude.ai/code)
 [![Version](https://img.shields.io/badge/Version-4.4-green)](https://github.com/cexll/myclaude)


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/cexll)](https://smithery.ai/skills?ns=cexll&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 3 skills have been installed **8 times** by **8 users** in the last 30 days.

### Top Skills
- **gemini** (6 activations, 6 users)
- **codex** (2 activations, 2 users)
- **requirements-clarity** (0 activations, 0 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!