### PR TITLE
fix(codeagent): 防止 Claude backend 无限递归调用

### DIFF
--- a/codeagent-wrapper/backend.go
+++ b/codeagent-wrapper/backend.go
@@ -36,6 +36,10 @@ func (ClaudeBackend) BuildArgs(cfg *Config, targetArg string) []string {
 	// 	args = append(args, "--dangerously-skip-permissions")
 	// }
 
+	// Prevent infinite recursion: disable all setting sources (user, project, local)
+	// This ensures a clean execution environment without CLAUDE.md or skills that would trigger codeagent
+	args = append(args, "--setting-sources", "")
+
 	if cfg.Mode == "resume" {
 		if cfg.SessionID != "" {
 			// Claude CLI uses -r <session_id> for resume.

--- a/codeagent-wrapper/backend_test.go
+++ b/codeagent-wrapper/backend_test.go
@@ -11,7 +11,7 @@ func TestClaudeBuildArgs_ModesAndPermissions(t *testing.T) {
 	t.Run("new mode uses workdir without skip by default", func(t *testing.T) {
 		cfg := &Config{Mode: "new", WorkDir: "/repo"}
 		got := backend.BuildArgs(cfg, "todo")
-		want := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose", "todo"}
+		want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--output-format", "stream-json", "--verbose", "todo"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
@@ -20,7 +20,7 @@ func TestClaudeBuildArgs_ModesAndPermissions(t *testing.T) {
 	t.Run("new mode opt-in skip permissions with default workdir", func(t *testing.T) {
 		cfg := &Config{Mode: "new", SkipPermissions: true}
 		got := backend.BuildArgs(cfg, "-")
-		want := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose", "-"}
+		want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--output-format", "stream-json", "--verbose", "-"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
@@ -29,7 +29,7 @@ func TestClaudeBuildArgs_ModesAndPermissions(t *testing.T) {
 	t.Run("resume mode uses session id and omits workdir", func(t *testing.T) {
 		cfg := &Config{Mode: "resume", SessionID: "sid-123", WorkDir: "/ignored"}
 		got := backend.BuildArgs(cfg, "resume-task")
-		want := []string{"-p", "--dangerously-skip-permissions", "-r", "sid-123", "--output-format", "stream-json", "--verbose", "resume-task"}
+		want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "-r", "sid-123", "--output-format", "stream-json", "--verbose", "resume-task"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
@@ -38,7 +38,7 @@ func TestClaudeBuildArgs_ModesAndPermissions(t *testing.T) {
 	t.Run("resume mode without session still returns base flags", func(t *testing.T) {
 		cfg := &Config{Mode: "resume", WorkDir: "/ignored"}
 		got := backend.BuildArgs(cfg, "follow-up")
-		want := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose", "follow-up"}
+		want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--output-format", "stream-json", "--verbose", "follow-up"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
 		}

--- a/codeagent-wrapper/main_test.go
+++ b/codeagent-wrapper/main_test.go
@@ -1377,7 +1377,7 @@ func TestBackendBuildArgs_ClaudeBackend(t *testing.T) {
 	backend := ClaudeBackend{}
 	cfg := &Config{Mode: "new", WorkDir: defaultWorkdir}
 	got := backend.BuildArgs(cfg, "todo")
-	want := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose", "todo"}
+	want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--output-format", "stream-json", "--verbose", "todo"}
 	if len(got) != len(want) {
 		t.Fatalf("length mismatch")
 	}
@@ -1398,7 +1398,7 @@ func TestClaudeBackendBuildArgs_OutputValidation(t *testing.T) {
 	target := "ensure-flags"
 
 	args := backend.BuildArgs(cfg, target)
-	expectedPrefix := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose"}
+	expectedPrefix := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--output-format", "stream-json", "--verbose"}
 
 	if len(args) != len(expectedPrefix)+1 {
 		t.Fatalf("args length=%d, want %d", len(args), len(expectedPrefix)+1)


### PR DESCRIPTION
## Summary

修复 `codeagent-wrapper --backend claude` 调用时的无限递归问题。

### 问题描述

当主 Claude 实例调用 codeagent-wrapper 使用 Claude backend 时，被调用的 Claude 会：
1. 读取 `~/.claude/CLAUDE.md`（包含调用 codeagent 的指令）
2. 加载 skills 配置
3. 再次尝试调用 codeagent → **导致循环超时** ❌

### 解决方案

在 `ClaudeBackend.BuildArgs()` 中添加 `--setting-sources ""` 参数，禁用所有配置源（user, project, local），确保子 Claude 实例在纯净环境中执行，避免加载会触发循环调用的配置。

### 修改内容

- **backend.go:39-41**: 添加 `--setting-sources ""` 参数
- **backend_test.go**: 更新 4 个测试用例以匹配新的参数列表
- **main_test.go**: 更新 2 个测试用例以匹配新的参数列表

### 调用链对比

**修改前：**
```
主 Claude (读 ~/.claude/CLAUDE.md + skills)
  → codeagent-wrapper --backend claude
    → 子 Claude (又读 ~/.claude/CLAUDE.md + skills)
      → 又调用 codeagent → 循环超时 ❌
```

**修改后：**
```
主 Claude (读 ~/.claude/CLAUDE.md + skills)
  → codeagent-wrapper --backend claude --setting-sources ""
    → 子 Claude (纯净执行，无任何配置)
      → 直接处理任务，无循环调用 ✅
```

## Test plan

- [x] 所有单元测试通过（5 个测试组）
- [x] 二进制已编译并验证
- [x] 修改向后兼容，不影响其他 backend（codex/gemini）

Generated with swe-agent-bot

Co-Authored-By: swe-agent-bot <agent@swe-agent.ai>