### PR TITLE
fix: allow claude backend to read env from setting.json while preventing recursion

### DIFF
--- a/codeagent-wrapper/executor_concurrent_test.go
+++ b/codeagent-wrapper/executor_concurrent_test.go
@@ -87,6 +87,7 @@ type execFakeRunner struct {
 	process         processHandle
 	stdin           io.WriteCloser
 	dir             string
+	env             map[string]string
 	waitErr         error
 	waitDelay       time.Duration
 	startErr        error
@@ -129,6 +130,17 @@ func (f *execFakeRunner) StdinPipe() (io.WriteCloser, error) {
 }
 func (f *execFakeRunner) SetStderr(io.Writer) {}
 func (f *execFakeRunner) SetDir(dir string)   { f.dir = dir }
+func (f *execFakeRunner) SetEnv(env map[string]string) {
+	if len(env) == 0 {
+		return
+	}
+	if f.env == nil {
+		f.env = make(map[string]string, len(env))
+	}
+	for k, v := range env {
+		f.env[k] = v
+	}
+}
 func (f *execFakeRunner) Process() processHandle {
 	if f.process != nil {
 		return f.process


### PR DESCRIPTION
## Summary

Fixes #89

Allows claude backend to read environment variables from `~/.claude/setting.json` while preventing infinite recursion from skills/commands/agents.

## Problem

- `--setting-sources ""` blocks all config sources, including env vars in setting.json
- Removing it causes claude to load `~/.claude/skills/codeagent`, triggering infinite recursion
- Users need ANTHROPIC_API_KEY from setting.json but don't want skills/commands loaded

## Solution

1. **Keep `--setting-sources ""`** to prevent reading CLAUDE.md/skills/agents
2. **Add `loadMinimalEnvSettings()`** function that:
   - Reads `~/.claude/setting.json`
   - Extracts only the `env` field
   - Returns it as JSON string
3. **Use `--settings` parameter** to explicitly pass env config to claude CLI

## Changes

### backend.go
- Added `loadMinimalEnvSettings()` to extract env from setting.json
- Modified `buildClaudeArgs()` to conditionally add `--settings` with env JSON
- Maintains `--setting-sources ""` to block skills/commands/agents

### Test files
- Updated `backend_test.go` and `main_test.go` to use prefix/suffix validation
- Tests now accommodate dynamic `--settings` parameter

## Testing

```bash
go test -v ./...
```

All tests pass (26.666s, 0 failures).

## Benefits

✅ Claude backend reads ANTHROPIC_API_KEY from setting.json  
✅ No infinite recursion from codeagent skill  
✅ Graceful degradation if setting.json doesn't exist  
✅ Clean separation: wrapper controls what config to pass  

Generated with SWE-Agent.ai 

Co-Authored-By: SWE-Agent.ai <noreply@swe-agent.ai>