### PR TITLE
fix(parser): 修复 Gemini init 事件 session_id 未提取的问题

### DIFF
--- a/codeagent-wrapper/main_test.go
+++ b/codeagent-wrapper/main_test.go
@@ -2096,6 +2096,16 @@ func TestBackendParseJSONStream_GeminiEvents(t *testing.T) {
 	}
 }
 
+func TestBackendParseJSONStream_GeminiInitEventSessionID(t *testing.T) {
+	input := `{"type":"init","session_id":"gemini-abc123"}`
+
+	_, threadID := parseJSONStream(strings.NewReader(input))
+
+	if threadID != "gemini-abc123" {
+		t.Fatalf("threadID=%q, want %q", threadID, "gemini-abc123")
+	}
+}
+
 func TestBackendParseJSONStream_GeminiEvents_DeltaFalseStillDetected(t *testing.T) {
 	input := `{"type":"init","session_id":"xyz789"}
 {"type":"message","content":"Hi","delta":false,"session_id":"xyz789"}

--- a/codeagent-wrapper/parser.go
+++ b/codeagent-wrapper/parser.go
@@ -171,7 +171,7 @@ func parseJSONStreamInternal(r io.Reader, warnFn func(string), infoFn func(strin
 		if !isClaude && event.Type == "result" && event.SessionID != "" && event.Status == "" {
 			isClaude = true
 		}
-		isGemini := event.Role != "" || event.Delta != nil || event.Status != ""
+		isGemini := (event.Type == "init" && event.SessionID != "") || event.Role != "" || event.Delta != nil || event.Status != ""
 
 		// Handle Codex events
 		if isCodex {


### PR DESCRIPTION
## 问题描述

使用 `codeagent-wrapper --backend gemini` 调用 Gemini CLI 后，未输出 `SESSION_ID`，导致无法使用 resume 功能延续会话。

## 根因分析

Gemini CLI 的 `session_id` 出现在 `init` 事件中：
```json
{"type":"init","timestamp":"...","session_id":"0e05a575-4e72-4315-b3a2-15a57457226d","model":"auto-gemini-3"}
```

但 `parser.go:174` 的 `isGemini` 判定条件只检查 `role/delta/status` 字段：
```go
isGemini := event.Role != "" || event.Delta != nil || event.Status != ""
```

导致 `init` 事件被当作 "Unknown event" 忽略（`parser.go:282`），`session_id` 无法提取。

Claude 后端正常是因为其 `session_id` 出现在 `type=="result"` 事件中，有专门的处理逻辑。

## 修复方案

在 `isGemini` 条件中增加对 `init` 事件的识别：
```go
isGemini := (event.Type == "init" && event.SessionID != "") || event.Role != "" || event.Delta != nil || event.Status != ""
```

## 改动文件

- `codeagent-wrapper/parser.go:174` - 修复 isGemini 判定条件
- `codeagent-wrapper/main_test.go` - 新增 `TestBackendParseJSONStream_GeminiInitEventSessionID` 单测

## 测试验证

```bash
# 单测通过
go test -v ./codeagent-wrapper/... -run TestBackendParseJSONStream_Gemini

# 实际验证
./codeagent-wrapper/codeagent-wrapper.exe --backend gemini - <<< "输出数字 42"
# 输出: SESSION_ID: f4036d62-f504-472b-8907-4e445e0e6d6f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)