### PR TITLE
fix(parser): 修复 Gemini init 事件 session_id 未提取的问题

### DIFF
--- a/codeagent-wrapper/main_test.go
+++ b/codeagent-wrapper/main_test.go
@@ -2096,6 +2096,16 @@ func TestBackendParseJSONStream_GeminiEvents(t *testing.T) {
 	}
 }
 
+func TestBackendParseJSONStream_GeminiInitEventSessionID(t *testing.T) {
+	input := `{"type":"init","session_id":"gemini-abc123"}`
+
+	_, threadID := parseJSONStream(strings.NewReader(input))
+
+	if threadID != "gemini-abc123" {
+		t.Fatalf("threadID=%q, want %q", threadID, "gemini-abc123")
+	}
+}
+
 func TestBackendParseJSONStream_GeminiEvents_DeltaFalseStillDetected(t *testing.T) {
 	input := `{"type":"init","session_id":"xyz789"}
 {"type":"message","content":"Hi","delta":false,"session_id":"xyz789"}

--- a/codeagent-wrapper/parser.go
+++ b/codeagent-wrapper/parser.go
@@ -171,7 +171,7 @@ func parseJSONStreamInternal(r io.Reader, warnFn func(string), infoFn func(strin
 		if !isClaude && event.Type == "result" && event.SessionID != "" && event.Status == "" {
 			isClaude = true
 		}
-		isGemini := event.Role != "" || event.Delta != nil || event.Status != ""
+		isGemini := (event.Type == "init" && event.SessionID != "") || event.Role != "" || event.Delta != nil || event.Status != ""
 
 		// Handle Codex events
 		if isCodex {


### PR DESCRIPTION
## 问题描述

使用 `codeagent-wrapper --backend gemini` 调用 Gemini CLI 后，未输出 `SESSION_ID`，导致无法使用 resume 功能延续会话。

## 说明（环境有限）：

仅本人Windows11使用遇到此问题，且修复完成后只在本机Windows环境测试通过

## 根因分析

Gemini CLI 的 `session_id` 出现在 `init` 事件中：
```json
{"type":"init","timestamp":"...","session_id":"0e05a575-4e72-4315-b3a2-15a57457226d","model":"auto-gemini-3"}
```

但 `parser.go:174` 的 `isGemini` 判定条件只检查 `role/delta/status` 字段：
```go
isGemini := event.Role != "" || event.Delta != nil || event.Status != ""
```

导致 `init` 事件被当作 "Unknown event" 忽略（`parser.go:282`），`session_id` 无法提取。

Claude 后端正常是因为其 `session_id` 出现在 `type=="result"` 事件中，有专门的处理逻辑。

## 修复方案

在 `isGemini` 条件中增加对 `init` 事件的识别：
```go
isGemini := (event.Type == "init" && event.SessionID != "") || event.Role != "" || event.Delta != nil || event.Status != ""
```

## 改动文件

- `codeagent-wrapper/parser.go:174` - 修复 isGemini 判定条件
- `codeagent-wrapper/main_test.go` - 新增 `TestBackendParseJSONStream_GeminiInitEventSessionID` 单测

## 手动测试记录

### Gemini 后端（修复目标）
```bash
# 第一次调用
$ ./codeagent-wrapper.exe --backend gemini - <<< "定义 count = 2.5，输出当前值"
count = 2.5
---
SESSION_ID: 7eb9dfa9-7bf2-45dd-9929-8d53c54d347a  ✅ 修复后正常输出

# Resume 调用
$ ./codeagent-wrapper.exe --backend gemini resume 7eb9dfa9-7bf2-45dd-9929-8d53c54d347a - <<< "把 count 加 1.1，输出新值"
3.6
---
SESSION_ID: 7eb9dfa9-7bf2-45dd-9929-8d53c54d347a  ✅ 会话延续正常 (2.5 + 1.1 = 3.6)
```

### Codex 后端（回归测试）
```bash
# 第一次调用
$ ./codeagent-wrapper.exe --backend codex - <<< "定义 count = 0，输出当前值"
count = 0
---
SESSION_ID: 019b9c1e-a3b0-75c2-9d1a-1c5c59e8d564  ✅

# Resume 调用
$ ./codeagent-wrapper.exe --backend codex resume 019b9c1e-a3b0-75c2-9d1a-1c5c59e8d564 - <<< "把 count 加 1，输出新值"
count = 1
---
SESSION_ID: 019b9c1e-a3b0-75c2-9d1a-1c5c59e8d564  ✅ 会话延续正常
```

### Claude 后端（回归测试）
```bash
# 第一次调用
$ ./codeagent-wrapper.exe --backend claude - <<< "定义 count = 0，输出当前值"
count=0
0
---
SESSION_ID: 1f868900-4028-492a-a409-e54ae9d4a822  ✅

# Resume 调用
$ ./codeagent-wrapper.exe --backend claude resume 1f868900-4028-492a-a409-e54ae9d4a822 - <<< "把 count 加 1，输出新值"
count=1
1
---
SESSION_ID: 1f868900-4028-492a-a409-e54ae9d4a822  ✅ 会话延续正常
```

## 单元测试

```bash
$ go test -v ./codeagent-wrapper/... -run TestBackendParseJSONStream_Gemini
=== RUN   TestBackendParseJSONStream_GeminiEvents
--- PASS: TestBackendParseJSONStream_GeminiEvents (0.00s)
=== RUN   TestBackendParseJSONStream_GeminiInitEventSessionID
--- PASS: TestBackendParseJSONStream_GeminiInitEventSessionID (0.00s)
=== RUN   TestBackendParseJSONStream_GeminiEvents_DeltaFalseStillDetected
--- PASS: TestBackendParseJSONStream_GeminiEvents_DeltaFalseStillDetected (0.00s)
=== RUN   TestBackendParseJSONStream_GeminiEvents_OnMessageTriggeredOnStatus
--- PASS: TestBackendParseJSONStream_GeminiEvents_OnMessageTriggeredOnStatus (0.00s)
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)