### PR TITLE
fix(codeagent-wrapper): 拒绝 '-' 作为 workdir 参数

### DIFF
--- a/codeagent-wrapper/config.go
+++ b/codeagent-wrapper/config.go
@@ -184,6 +184,10 @@ func parseParallelConfig(data []byte) (*ParallelConfig, error) {
 			case "id":
 				task.ID = value
 			case "workdir":
+				// Validate workdir: "-" is not a valid directory
+				if value == "-" {
+					return nil, fmt.Errorf("task block #%d has invalid workdir: '-' is not a valid directory path", taskIndex)
+				}
 				task.WorkDir = value
 			case "session_id":
 				task.SessionID = value
@@ -417,6 +421,10 @@ func parseArgs() (*Config, error) {
 		cfg.Task = args[2]
 		cfg.ExplicitStdin = (args[2] == "-")
 		if len(args) > 3 {
+			// Validate workdir: "-" is not a valid directory
+			if args[3] == "-" {
+				return nil, fmt.Errorf("invalid workdir: '-' is not a valid directory path")
+			}
 			cfg.WorkDir = args[3]
 		}
 	} else {
@@ -424,6 +432,10 @@ func parseArgs() (*Config, error) {
 		cfg.Task = args[0]
 		cfg.ExplicitStdin = (args[0] == "-")
 		if len(args) > 1 {
+			// Validate workdir: "-" is not a valid directory
+			if args[1] == "-" {
+				return nil, fmt.Errorf("invalid workdir: '-' is not a valid directory path")
+			}
 			cfg.WorkDir = args[1]
 		}
 	}

--- a/codeagent-wrapper/main_test.go
+++ b/codeagent-wrapper/main_test.go
@@ -1095,6 +1095,11 @@ func TestBackendParseArgs_NewMode(t *testing.T) {
 			args: []string{"codeagent-wrapper", "-", "/some/dir"},
 			want: &Config{Mode: "new", Task: "-", WorkDir: "/some/dir", ExplicitStdin: true, Backend: defaultBackendName},
 		},
+		{
+			name:    "stdin with dash workdir rejected",
+			args:    []string{"codeagent-wrapper", "-", "-"},
+			wantErr: true,
+		},
 		{name: "no args", args: []string{"codeagent-wrapper"}, wantErr: true},
 	}
 
@@ -1156,6 +1161,7 @@ func TestBackendParseArgs_ResumeMode(t *testing.T) {
 		{name: "resume missing task", args: []string{"codeagent-wrapper", "resume", "session-123"}, wantErr: true},
 		{name: "resume empty session_id", args: []string{"codeagent-wrapper", "resume", "", "task"}, wantErr: true},
 		{name: "resume whitespace session_id", args: []string{"codeagent-wrapper", "resume", "   ", "task"}, wantErr: true},
+		{name: "resume with dash workdir rejected", args: []string{"codeagent-wrapper", "resume", "session-123", "task", "-"}, wantErr: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 问题描述

当用户执行 `codeagent-wrapper - -` 时，第二个 `-` 会被错误解析为 workdir 目录路径。

`-` 不是有效的目录路径，应该在参数解析阶段立即拒绝，而不是等到后续执行时才产生混乱的错误。

## 修复内容

在以下 3 处添加 workdir 参数校验：
- 新建模式 (`codeagent-wrapper <task> <workdir>`)
- 恢复模式 (`codeagent-wrapper resume <session_id> <task> <workdir>`)
- 并行模式配置解析 (`workdir: -`)

## 测试

添加 2 个测试用例覆盖新建模式和恢复模式的校验逻辑，所有测试通过。

## 影响范围

- **向后兼容**：`-` 从来不是合法的目录路径，无用户依赖此行为
- **行为变更**：原来静默接受后运行时失败 → 现在解析时立即报错，体验更好
- **破坏性影响**：无