### PR TITLE
fix(gemini): read GEMINI_MODEL from ~/.gemini/.env

### DIFF
--- a/codeagent-wrapper/internal/executor/executor.go
+++ b/codeagent-wrapper/internal/executor/executor.go
@@ -940,6 +940,11 @@ func RunCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	// Load gemini env from ~/.gemini/.env if exists
 	if cfg.Backend == "gemini" {
 		fileEnv = loadGeminiEnv()
+		if cfg.Mode != "resume" && strings.TrimSpace(cfg.Model) == "" {
+			if model := fileEnv["GEMINI_MODEL"]; model != "" {
+				cfg.Model = model
+			}
+		}
 	}
 
 	useStdin := taskSpec.UseStdin


### PR DESCRIPTION
## Summary
- When using gemini backend without `--model` flag, now automatically reads `GEMINI_MODEL` from `~/.gemini/.env` file
- Consistent with how claude backend reads model from settings

## Problem
Previously, even if `GEMINI_MODEL` was configured in `~/.gemini/.env`, the gemini backend would ignore it and use the default model (`gemini-3-pro-preview`). Users had to always pass `--model` flag explicitly.

## Solution
Added logic to read `GEMINI_MODEL` from the loaded env file when `cfg.Model` is empty (similar to claude backend's behavior).

## Test plan
1. Set `GEMINI_MODEL=gemini-3-flash-preview` in `~/.gemini/.env`
2. Run `codeagent-wrapper --backend gemini "hello"`
3. Verify it uses `gemini-3-flash-preview` instead of default model