### PR TITLE
feat(backend): add Kimi CLI backend to codeagent-wrapper

### DIFF
--- a/codeagent-wrapper/internal/backend/kimi.go
+++ b/codeagent-wrapper/internal/backend/kimi.go
@@ -1,0 +1,104 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	config "codeagent-wrapper/internal/config"
+)
+
+type KimiBackend struct{}
+
+func (KimiBackend) Name() string    { return "kimi" }
+func (KimiBackend) Command() string { return "kimi" }
+func (KimiBackend) Env(baseURL, apiKey string) map[string]string {
+	baseURL = strings.TrimSpace(baseURL)
+	apiKey = strings.TrimSpace(apiKey)
+	if baseURL == "" && apiKey == "" {
+		return nil
+	}
+	env := make(map[string]string, 2)
+	if baseURL != "" {
+		env["KIMI_BASE_URL"] = baseURL
+	}
+	if apiKey != "" {
+		env["KIMI_API_KEY"] = apiKey
+	}
+	return env
+}
+func (KimiBackend) BuildArgs(cfg *config.Config, targetArg string) []string {
+	return buildKimiArgs(cfg, targetArg)
+}
+
+// LoadKimiEnv loads environment variables from ~/.kimi/.env if it exists.
+// Supports KIMI_API_KEY, KIMI_BASE_URL, KIMI_MODEL_NAME.
+func LoadKimiEnv() map[string]string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil
+	}
+
+	envDir := filepath.Clean(filepath.Join(home, ".kimi"))
+	envPath := filepath.Clean(filepath.Join(envDir, ".env"))
+	rel, err := filepath.Rel(envDir, envPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return nil
+	}
+
+	data, err := os.ReadFile(envPath) // #nosec G304 -- path is fixed under user home and validated within envDir
+	if err != nil {
+		return nil
+	}
+
+	env := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, '=')
+		if idx <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		value := strings.TrimSpace(line[idx+1:])
+		if key != "" && value != "" {
+			env[key] = value
+		}
+	}
+
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+func buildKimiArgs(cfg *config.Config, targetArg string) []string {
+	if cfg == nil {
+		return nil
+	}
+	// --print: non-interactive mode (implies --yolo)
+	// --output-format stream-json: JSON line output
+	// --final-message-only: emit only the final assistant message
+	args := []string{"--print", "--output-format", "stream-json", "--final-message-only"}
+
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		args = append(args, "-m", model)
+	}
+
+	if cfg.Mode == "resume" && cfg.SessionID != "" {
+		args = append(args, "-S", cfg.SessionID)
+	}
+
+	// Working directory is set via cmd.SetDir in the executor (like Claude/Gemini).
+	// kimi defaults to the process CWD when --work-dir is omitted.
+
+	if targetArg != "-" {
+		args = append(args, "-p", targetArg)
+	}
+	// When targetArg == "-", task is written to stdin.
+	// kimi reads stdin automatically when it is not a TTY and --input-format is "text" (the default).
+
+	return args
+}

--- a/codeagent-wrapper/internal/backend/registry.go
+++ b/codeagent-wrapper/internal/backend/registry.go
@@ -10,6 +10,7 @@ var registry = map[string]Backend{
 	"claude":   ClaudeBackend{},
 	"gemini":   GeminiBackend{},
 	"opencode": OpencodeBackend{},
+	"kimi":     KimiBackend{},
 }
 
 // Registry exposes the available backends. Intended for internal inspection/tests.

--- a/codeagent-wrapper/internal/executor/executor.go
+++ b/codeagent-wrapper/internal/executor/executor.go
@@ -71,6 +71,8 @@ func loadMinimalClaudeSettings() minimalClaudeSettings { return backend.LoadMini
 
 func loadGeminiEnv() map[string]string { return backend.LoadGeminiEnv() }
 
+func loadKimiEnv() map[string]string { return backend.LoadKimiEnv() }
+
 func NewLogger() (*Logger, error) { return ilogger.NewLogger() }
 
 func NewLoggerWithSuffix(suffix string) (*Logger, error) { return ilogger.NewLoggerWithSuffix(suffix) }
@@ -1021,6 +1023,16 @@ func RunCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 		}
 	}
 
+	// Load kimi env from ~/.kimi/.env if exists
+	if cfg.Backend == "kimi" {
+		fileEnv = loadKimiEnv()
+		if cfg.Mode != "resume" && strings.TrimSpace(cfg.Model) == "" {
+			if model := fileEnv["KIMI_MODEL_NAME"]; model != "" {
+				cfg.Model = model
+			}
+		}
+	}
+
 	useStdin := taskSpec.UseStdin
 	targetArg := taskSpec.Task
 	if useStdin {
@@ -1194,6 +1206,9 @@ func RunCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 			stderrOut = stderrFilter
 		} else if cfg.Backend == "codex" {
 			stderrFilter = newFilteringWriter(os.Stderr, codexNoisePatterns)
+			stderrOut = stderrFilter
+		} else if cfg.Backend == "kimi" {
+			stderrFilter = newFilteringWriter(os.Stderr, kimiNoisePatterns)
 			stderrOut = stderrFilter
 		}
 		stderrWriters = append([]io.Writer{stderrOut}, stderrWriters...)

--- a/codeagent-wrapper/internal/executor/filter.go
+++ b/codeagent-wrapper/internal/executor/filter.go
@@ -23,6 +23,14 @@ var codexNoisePatterns = []string{
 	"ERROR codex_core::",
 }
 
+// kimiNoisePatterns contains stderr patterns to filter for kimi backend
+var kimiNoisePatterns = []string{
+	"[INFO]",
+	"[DEBUG]",
+	"Loaded cached",
+	"Loading extension:",
+}
+
 // filteringWriter wraps an io.Writer and filters out lines matching patterns
 type filteringWriter struct {
 	w        io.Writer

--- a/skills/codeagent/SKILL.md
+++ b/skills/codeagent/SKILL.md
@@ -29,7 +29,7 @@ codeagent-wrapper --parallel [flags] < tasks_config
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--backend <name>` | Backend: codex, claude, gemini, opencode | codex |
+| `--backend <name>` | Backend: codex, claude, gemini, opencode, kimi | codex |
 | `--agent <name>` | Agent preset (from models.json or agents/ dir) | none |
 | `--model <name>` | Model override for any backend | backend default |
 | `--skills <names>` | Comma-separated skill names to inject | auto-detected |
@@ -52,6 +52,7 @@ codeagent-wrapper --parallel [flags] < tasks_config
 | **Claude** | `--backend claude` | Documentation, prompt engineering, clear-requirement features |
 | **Gemini** | `--backend gemini` | UI/UX prototyping, design system implementation |
 | **OpenCode** | `--backend opencode` | Lightweight tasks, minimal feature set |
+| **Kimi** | `--backend kimi` | Long-context tasks, large codebase ingestion, multi-file analysis |
 
 ## Agent Presets
 


### PR DESCRIPTION
## Summary

Adds [Moonshot Kimi](https://moonshotai.github.io/kimi-cli/) as a fifth pluggable backend alongside Codex, Claude, Gemini, and OpenCode.

### Changes

- **`internal/backend/kimi.go`** — new `KimiBackend` struct implementing the `Backend` interface
  - Invokes `kimi --print --output-format stream-json --final-message-only`
  - Stdin mode: kimi reads from stdin when `-p` is omitted and stdin is a pipe
  - Session resume via `-S <session_id>` (ID printed to stderr by kimi)
  - `LoadKimiEnv()` reads `~/.kimi/.env` for `KIMI_API_KEY`, `KIMI_BASE_URL`, `KIMI_MODEL_NAME`
- **`internal/backend/registry.go`** — registers `"kimi": KimiBackend{}`
- **`internal/executor/executor.go`** — kimi env loading block + stderr noise filter wired in
- **`internal/executor/filter.go`** — adds `kimiNoisePatterns`
- **`skills/codeagent/SKILL.md`** — documents kimi backend in the backends table

### How it works

Kimi's `--final-message-only --output-format stream-json` emits a single `{"role":"assistant","content":"text"}` JSON line. The existing Gemini parser path handles this since it detects `event.Role != ""`.

### Testing

Tested locally with an authenticated kimi session — returns correct response and session ID.

```
$ codeagent-wrapper --backend kimi "say hello in one sentence" .
Hello! I'm Kimi Code CLI, ready to help you with your software engineering tasks.
```

## Auth setup

Users need to run `kimi login` once, or set `KIMI_API_KEY` in `~/.kimi/.env`.
